### PR TITLE
Add new FilterListSelector that uses grid to render items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-taggable-text-area-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Taggable Text Area Parent</name>
 

--- a/vcf-taggable-text-area-demo/pom.xml
+++ b/vcf-taggable-text-area-demo/pom.xml
@@ -9,7 +9,7 @@
     <packaging>war</packaging>
     <name>Taggable Text Area Demo</name>
 
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <inceptionYear>2024</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/vcf-taggable-text-area-demo/src/main/java/org/vaadin/addons/componentfactory/demo/TaggableTextAreaDemoView.java
+++ b/vcf-taggable-text-area-demo/src/main/java/org/vaadin/addons/componentfactory/demo/TaggableTextAreaDemoView.java
@@ -19,14 +19,6 @@
  */
 package org.vaadin.addons.componentfactory.demo;
 
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.vaadin.addons.componentfactory.tta.FilterListBoxSelector;
-import org.vaadin.addons.componentfactory.tta.TaggableTextArea;
-
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Focusable;
@@ -49,6 +41,13 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.vaadin.addons.componentfactory.tta.FilterListSelector;
+import org.vaadin.addons.componentfactory.tta.TaggableTextArea;
 
 /**
  * View for {@link TaggableTextArea} demo.
@@ -59,202 +58,239 @@ import com.vaadin.flow.router.Route;
 @Route("")
 public class TaggableTextAreaDemoView extends DemoView {
 
-    @Override
-    public void initView() {
-        createBasicTaggableTextAreaDemo();
-        createGridDemo();
+  @Override
+  public void initView() {
+    createBasicTaggableTextAreaDemo();
+    createGridDemo();
 
-        addCard("Additional code used in the demo",
-                new Span("These methods are used in the demo."));
-    }
+    addCard("Additional code used in the demo", new Span("These methods are used in the demo."));
+  }
 
-    @SuppressWarnings("rawtypes")
-	private void createGridDemo() {
-    	
-        // begin-source-example
-        // source-example-heading: Grid demo for TaggableTextArea
-    	Grid<User> usersGrid = new Grid<>();
-    	usersGrid.setItems(Arrays.asList(
-				new User("John Doe", "jdoe@example.com", "", LocalDate.now(),"https://randomuser.me/api/portraits/men/77.jpg"),
-				new User("Jane Doe", "jane@example.com", "", LocalDate.now(),"https://randomuser.me/api/portraits/women/43.jpg")));
-    	Editor<User> editor = usersGrid.getEditor();
-    	Grid.Column<User> nameColumn = usersGrid.addColumn(User::getName).setHeader("Name");
-    	Grid.Column<User> emailColumn = usersGrid.addColumn(User::getEmail).setHeader("Email");
-    	Grid.Column<User> notesColumn = usersGrid.addColumn(new ComponentRenderer<>(user->{
-    		Span span = new Span();
-    		span.getElement().executeJs("this.innerHTML = $0",user.getNotes());
-    		return span;
-    	})).setHeader("Notes").setResizable(true);
-    	Grid.Column<User> birthDateColumn = usersGrid.addColumn(User::getBirthDate).setHeader("Birthdate");
-    	Grid.Column<User> editColumn = usersGrid.addComponentColumn(person -> {
-    	    Button editButton = new Button("Edit");
-    	    editButton.addClickListener(e -> {
-    	        if (editor.isOpen())
-    	            editor.cancel();
-    	        usersGrid.getEditor().editItem(person);
-    	    });
-    	    return editButton;
-    	}).setWidth("150px").setFlexGrow(0);
-    	Binder<User> binder = new Binder<>();
-    	editor.setBinder(binder);
-    	
-    	TextField nameField = new TextField();
-    	nameField.setWidthFull();
-    	binder.forField(nameField)
-    			.asRequired("Name must not be empty")
-    			.bind(User::getName, User::setName);
-    	nameColumn.setEditorComponent(nameField);
-    	
-    	TextField emailField = new TextField();
-    	emailField.setWidthFull();
-    	binder.forField(emailField)
-    		.asRequired("Email must not be empty")
-    		    .bind(User::getEmail, User::setEmail);
-    	emailColumn.setEditorComponent(emailField);
-    	
-    	TaggableTextArea<User> notesField = createTaggableTextArea();
-    	notesField.setWidthFull();
-    	binder.forField(notesField)
-    		.bind(User::getNotes,User::setNotes);
-    	notesColumn.setEditorComponent(notesField);
-    	notesField.setHeight("100px");
-    	
-    	DatePicker birthDateField = new DatePicker();
-    	birthDateField.setWidthFull();
-    	binder.forField(birthDateField)
-    	    .bind(User::getBirthDate, User::setBirthDate);
-    		birthDateColumn.setEditorComponent(birthDateField);
-    	birthDateColumn.setEditorComponent(birthDateField);
-    	
-    	Button saveButton = new Button("Save", e -> {
-    		editor.save();
-    		editor.closeEditor();
-    		editor.getBinder().getBean().setNotes(notesField.getPlainValue());
-    		usersGrid.getDataCommunicator().refresh(editor.getBinder().getBean());
-    	});
-    	Button cancelButton = new Button(VaadinIcon.CLOSE.create(),
-    	        e -> editor.cancel());
-    	cancelButton.addThemeVariants(ButtonVariant.LUMO_ICON,
-    	        ButtonVariant.LUMO_ERROR);
-    	HorizontalLayout actions = new HorizontalLayout(saveButton,
-    	        cancelButton);
-    	actions.setPadding(false);
-    	editColumn.setEditorComponent(actions);
-    	
-    	usersGrid.addItemDoubleClickListener(e -> {
-            editor.editItem(e.getItem());
-            Component editorComponent = e.getColumn().getEditorComponent();
-            if (editorComponent instanceof Focusable) {
-                ((Focusable) editorComponent).focus();
-            }
-        });
-    	
-        // end-source-example
-        addCard("Grid Example", usersGrid);
-	}
-
-	private void createBasicTaggableTextAreaDemo() {
-        Div message = createMessageDiv("simple-taggable-text-area-demo-message");
-        message.getStyle().set("text-wrap", "auto");
-        Div plainMessage = createMessageDiv("simple-taggable-text-area-demo-plain-message");
-        plainMessage.getStyle().set("text-wrap", "auto");
-
-        // begin-source-example
-        // source-example-heading: Simple example for TaggableTextArea
-        TaggableTextArea<User> tta = createTaggableTextArea();
-        tta.setHeight("200px");
-        tta.setLabel("Enter text, use @ to tag user");
-        tta.addValueChangeListener(ev->{
-            updateMessage(message, tta.getValue());
-            updateMessage(plainMessage, tta.getPlainValue());
-        });
-        tta.setValue("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rutrum diam sed sem interdum semper. "
-        		+ "<div>Morbi velit mi, interdum eu luctus sit amet, imperdiet et nisi. Praesent odio metus, porttitor mattis diam eu, </div>"
-        		+ "<div>mattis rutrum lectus. John Doe. Pellentesque elementum non urna vitae commodo. Praesent finibus nunc purus, eget </div>"
-        		+ "<div>facilisis tortor sollicitudin id. Etiam accumsan nisl mauris, eu semper nisl convallis facilisis. Jane Doe.</div>"
-        		+ "<div>Sed varius volutpat aliquam. Suspendisse augue augue, maximus fermentum sagittis varius, commodo </div>"
-        		+ "<div>id eros. Nunc vulputate justo vel sagittis ultrices. Quisque vehicula lorem in orci elementum interdum. </div>"
-        		+ "<div>In in sem quis dolor convallis aliquet sed fermentum mi.</div>");
-        tta.setTagPopupFor(item->item.getName().equals("John Doe"));
-        
-        showUsedTags(tta.obtainUsedTags());
-        Checkbox cb = new Checkbox("Readonly");
-        cb.addValueChangeListener(ev -> tta.setReadOnly(cb.getValue()));
-        Button showUsedTags = new Button("Show used tags", ev-> showUsedTags(tta.obtainUsedTags()));
-        // end-source-example
-
-        addCard("Simple Example", tta, message, plainMessage, new HorizontalLayout(showUsedTags,cb));
-    }
-
-	private TaggableTextArea<User> createTaggableTextArea() {
-		TaggableTextArea<User> tta = new TaggableTextArea<User>(
-        		Arrays.asList(
-        				new User("John Doe", "jdoe@example.com", "", LocalDate.now(),"https://randomuser.me/api/portraits/men/77.jpg"),
-        				new User("Jane Doe", "jane@example.com", "", LocalDate.now(),"https://randomuser.me/api/portraits/women/43.jpg"))) {
-        	@Override
-        	protected Component createTagPopupContent(User relatedItem) {
-        		return new Button("Show user information", ev-> {
-        			Notification.show("User: " + relatedItem.getName() + ", Email: " + relatedItem.getEmail());
-        		});
-        	}
-        	@Override
-			protected AbstractField<?, User> createSelector() {
-				return TaggableTextAreaDemoView.createSelector(this.items);
-			}
-        };
-        tta.setWidthFull();
-		return tta;
-	}
-
-	private void showUsedTags(List<User> users) {
-    	Notification.show("Users: " + users.stream().map(item -> item.getName() + ", " + item.getEmail()).collect(Collectors.joining(",")));
-	}
-
-	// begin-source-example
-    // source-example-heading: Additional code used in the demo
-    /**
-     * Additional code used in the demo
-     */
-    private void updateMessage(Div message, String value) {
-    	message.getElement().setProperty("innerHTML", value);
-    }
-
-    private Div createMessageDiv(String id) {
-        Div message = new Div();
-        message.setId(id);
-        message.getStyle().set("whiteSpace", "pre");
-        return message;
-    }
-
+  @SuppressWarnings("rawtypes")
+  private void createGridDemo() {
     
-    protected static AbstractField<?, User> createSelector(List<User> items) {
-    	FilterListBoxSelector<User> selector = new FilterListBoxSelector<>(items);
-    	selector.setFilterExpression((item,filter) -> item.getName().toLowerCase().contains(filter.toLowerCase()));
-    	selector.setRenderer(new ComponentRenderer<>(person -> {
-    		    HorizontalLayout row = new HorizontalLayout();
-    		    row.setAlignItems(FlexComponent.Alignment.CENTER);
+    // begin-source-example
+    // source-example-heading: TaggableTextArea used on Grid
+    Grid<User> usersGrid = new Grid<>();
+    usersGrid.setItems(Arrays.asList(
+        new User("John Doe", "jdoe@example.com", "", LocalDate.now(),
+            "https://randomuser.me/api/portraits/men/77.jpg"),
+        new User("Jane Doe", "jane@example.com", "", LocalDate.now(),
+            "https://randomuser.me/api/portraits/women/43.jpg")));
 
-    		    Avatar avatar = new Avatar();
-    		    avatar.setName(person.getName());
-    		    avatar.setImage(person.getPictureUrl());
+    Editor<User> editor = usersGrid.getEditor();
+    Grid.Column<User> nameColumn = usersGrid.addColumn(User::getName).setHeader("Name");
+    Grid.Column<User> emailColumn = usersGrid.addColumn(User::getEmail).setHeader("Email");
+    Grid.Column<User> notesColumn = usersGrid.addColumn(new ComponentRenderer<>(user -> {
+      Span span = new Span();
+      span.getElement().executeJs("this.innerHTML = $0", user.getNotes());
+      return span;
+    })).setHeader("Notes").setResizable(true);
+    Grid.Column<User> birthDateColumn =
+        usersGrid.addColumn(User::getBirthDate).setHeader("Birthdate");
+    Grid.Column<User> editColumn = usersGrid.addComponentColumn(person -> {
+      Button editButton = new Button("Edit");
+      editButton.addClickListener(e -> {
+        if (editor.isOpen())
+          editor.cancel();
+        usersGrid.getEditor().editItem(person);
+      });
+      return editButton;
+    }).setWidth("150px").setFlexGrow(0);
+    Binder<User> binder = new Binder<>();
+    editor.setBinder(binder);
 
-    		    Span name = new Span(person.getName());
-    		    Span profession = new Span(person.getEmail());
-    		    profession.getStyle()
-    		        .set("color", "var(--lumo-secondary-text-color)")
-    		        .set("font-size", "var(--lumo-font-size-s)");
+    TextField nameField = new TextField();
+    nameField.setWidthFull();
+    binder.forField(nameField).asRequired("Name must not be empty").bind(User::getName,
+        User::setName);
+    nameColumn.setEditorComponent(nameField);
 
-    		    VerticalLayout column = new VerticalLayout(name, profession);
-    		    column.setPadding(false);
-    		    column.setSpacing(false);
+    TextField emailField = new TextField();
+    emailField.setWidthFull();
+    binder.forField(emailField).asRequired("Email must not be empty").bind(User::getEmail,
+        User::setEmail);
+    emailColumn.setEditorComponent(emailField);
 
-    		    row.add(avatar, column);
-    		    row.getStyle().set("line-height", "var(--lumo-line-height-m)");
-    		    return row;
-    		}));
-    	
-		return selector;
-	}
-    
+    TaggableTextArea<User> notesField = createGridTaggableTextArea();
+    notesField.setWidthFull();
+    binder.forField(notesField).bind(User::getNotes, User::setNotes);
+    notesColumn.setEditorComponent(notesField);
+    notesField.setHeight("100px");
+
+    DatePicker birthDateField = new DatePicker();
+    birthDateField.setWidthFull();
+    binder.forField(birthDateField).bind(User::getBirthDate, User::setBirthDate);
+    birthDateColumn.setEditorComponent(birthDateField);
+    birthDateColumn.setEditorComponent(birthDateField);
+
+    Button saveButton = new Button("Save", e -> {
+      editor.save();
+      editor.closeEditor();
+      editor.getBinder().getBean().setNotes(notesField.getPlainValue());
+      usersGrid.getDataCommunicator().refresh(editor.getBinder().getBean());
+    });
+    Button cancelButton = new Button(VaadinIcon.CLOSE.create(), e -> editor.cancel());
+    cancelButton.addThemeVariants(ButtonVariant.LUMO_ICON, ButtonVariant.LUMO_ERROR);
+    HorizontalLayout actions = new HorizontalLayout(saveButton, cancelButton);
+    actions.setPadding(false);
+    editColumn.setEditorComponent(actions);
+
+    usersGrid.addItemDoubleClickListener(e -> {
+      editor.editItem(e.getItem());
+      Component editorComponent = e.getColumn().getEditorComponent();
+      if (editorComponent instanceof Focusable) {
+        ((Focusable) editorComponent).focus();
+      }
+    });
     // end-source-example
+    
+    addCard("TaggableTextArea used on Grid", usersGrid);
+  }
+
+  private void createBasicTaggableTextAreaDemo() {
+    Div message = createMessageDiv("simple-taggable-text-area-demo-message");
+    Div plainMessage = createMessageDiv("simple-taggable-text-area-demo-plain-message");
+
+    // begin-source-example
+    // source-example-heading: Simple example for TaggableTextArea
+    TaggableTextArea<User> tta = createBasicTaggableTextArea();
+    tta.setHeight("200px");
+    tta.setLabel("Enter text, use @ to tag user");
+    tta.addValueChangeListener(ev -> {
+      updateMessage(message, "<b>Text Area Value:</b> <br>" + tta.getValue());
+      updateMessage(plainMessage, "<b>Text Area Plain Value:</b> <br>" + tta.getPlainValue());
+    });
+    tta.setValue(
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rutrum diam sed sem interdum semper. "
+            + "<div>Morbi velit mi, interdum eu luctus sit amet, imperdiet et nisi. Praesent odio metus, porttitor mattis diam eu, </div>"
+            + "<div>mattis rutrum lectus. John Doe. Pellentesque elementum non urna vitae commodo. Praesent finibus nunc purus, eget </div>"
+            + "<div>facilisis tortor sollicitudin id. Etiam accumsan nisl mauris, eu semper nisl convallis facilisis. Jane Doe.</div>"
+            + "<div>Sed varius volutpat aliquam. Suspendisse augue augue, maximus fermentum sagittis varius, commodo </div>"
+            + "<div>id eros. Nunc vulputate justo vel sagittis ultrices. Quisque vehicula lorem in orci elementum interdum. </div>"
+            + "<div>In in sem quis dolor convallis aliquet sed fermentum mi. </div>");
+    tta.setTagPopupFor(item -> item.getName().equals("John Doe"));
+
+    showUsedTags(tta.obtainUsedTags());
+    Checkbox cb = new Checkbox("Readonly");
+    cb.addValueChangeListener(ev -> tta.setReadOnly(cb.getValue()));
+    Button showUsedTags = new Button("Show used tags", ev -> showUsedTags(tta.obtainUsedTags()));
+    // end-source-example
+
+    addCard("Simple example for TaggableTextArea", tta, message, plainMessage,
+        new HorizontalLayout(showUsedTags, cb));
+  }
+
+  // begin-source-example
+  // source-example-heading: Additional code used in the demo
+  /**
+   * Additional code used in the demo
+   */
+  private void updateMessage(Div message, String value) {
+    message.getElement().setProperty("innerHTML", value);
+  }
+
+  private Div createMessageDiv(String id) {
+    Div message = new Div();
+    message.setId(id);
+    message.getStyle().set("whiteSpace", "normal");
+    return message;
+  }
+
+  private TaggableTextArea<User> createBasicTaggableTextArea() {
+    TaggableTextArea<User> tta = new TaggableTextArea<User>(Arrays.asList(
+        new User("John Doe", "jdoe@example.com", "", LocalDate.now(),
+            "https://randomuser.me/api/portraits/men/77.jpg"),
+        new User("Jane Doe", "jane@example.com", "", LocalDate.now(),
+            "https://randomuser.me/api/portraits/women/43.jpg"))) {
+      
+      @Override
+      protected Component createTagPopupContent(User relatedItem) {
+        return createTagPopupButton(relatedItem);
+      }
+
+    };
+    tta.setWidthFull();
+    return tta;
+  }  
+
+  private TaggableTextArea<User> createGridTaggableTextArea() {
+    TaggableTextArea<User> tta = new TaggableTextArea<User>(getPopupItems()) {
+      
+      @Override
+      protected Component createTagPopupContent(User relatedItem) {
+        return createTagPopupButton(relatedItem);
+      }
+
+      @Override
+      protected AbstractField<?, User> createSelector() {
+        return TaggableTextAreaDemoView.createGridSelector(this.items);
+      }
+      
+    };
+    tta.setWidthFull();
+    return tta;
+  }
+  
+  private Button createTagPopupButton(User relatedItem) {
+    return new Button("Show user information", ev -> {
+      Notification
+          .show("User: " + relatedItem.getName() + ", Email: " + relatedItem.getEmail());
+    });
+  }
+  
+  private void showUsedTags(List<User> users) {
+    Notification.show("Users: " + users.stream()
+        .map(item -> item.getName() + ", " + item.getEmail()).collect(Collectors.joining(",")));
+  }
+  
+  private static final String[] RANDOM_USERS_PICTURES =
+      new String[] {"https://randomuser.me/api/portraits/men/35.jpg",
+          "https://randomuser.me/api/portraits/women/51.jpg",
+          "https://randomuser.me/api/portraits/men/77.jpg",
+          "https://randomuser.me/api/portraits/women/43.jpg"};
+
+  private List<User> getPopupItems() {
+    List<User> items = new ArrayList<User>();
+    for (int i = 0; i < 10; i++) {
+      String name = "user" + (i + 1);
+      items.add(new User(name, name + "@example.com", "", LocalDate.now(),
+          RANDOM_USERS_PICTURES[(int) (Math.random() * 4)]));
+    }
+    return items;
+  }
+
+  protected static AbstractField<?, User> createGridSelector(List<User> items) {
+    FilterListSelector<User> selector = new FilterListSelector<>(items, createItemRenderer());
+    selector.setWidth("200px");
+    selector.setFilterExpression(
+        (item, filter) -> item.getName().toLowerCase().contains(filter.toLowerCase()));
+    return selector;
+  }
+
+  private static ComponentRenderer<Component, User> createItemRenderer() {
+    return new ComponentRenderer<Component, User>(user -> {
+      HorizontalLayout row = new HorizontalLayout();
+      row.setAlignItems(FlexComponent.Alignment.CENTER);
+
+      Avatar avatar = new Avatar();
+      avatar.setName(user.getName());
+      avatar.setImage(user.getPictureUrl());
+
+      Span name = new Span(user.getName());
+      Span profession = new Span(user.getEmail());
+      profession.getStyle().set("color", "var(--lumo-secondary-text-color)").set("font-size",
+          "var(--lumo-font-size-s)");
+
+      VerticalLayout column = new VerticalLayout(name, profession);
+      column.setPadding(false);
+      column.setSpacing(false);
+
+      row.add(avatar, column);
+      row.getStyle().set("line-height", "var(--lumo-line-height-m)");
+      return row;
+    });
+  }
+
+  // end-source-example
 }

--- a/vcf-taggable-text-area-demo/src/main/java/org/vaadin/addons/componentfactory/demo/TaggableTextAreaDemoView.java
+++ b/vcf-taggable-text-area-demo/src/main/java/org/vaadin/addons/componentfactory/demo/TaggableTextAreaDemoView.java
@@ -168,7 +168,7 @@ public class TaggableTextAreaDemoView extends DemoView {
             + "<div>facilisis tortor sollicitudin id. Etiam accumsan nisl mauris, eu semper nisl convallis facilisis. Jane Doe.</div>"
             + "<div>Sed varius volutpat aliquam. Suspendisse augue augue, maximus fermentum sagittis varius, commodo </div>"
             + "<div>id eros. Nunc vulputate justo vel sagittis ultrices. Quisque vehicula lorem in orci elementum interdum. </div>"
-            + "<div>In in sem quis dolor convallis aliquet sed fermentum mi. </div>");
+            + "<div>In in sem quis dolor convallis aliquet sed fermentum mi. Jane Doe </div>");
     tta.setTagPopupFor(item -> item.getName().equals("John Doe"));
 
     showUsedTags(tta.obtainUsedTags());

--- a/vcf-taggable-text-area/pom.xml
+++ b/vcf-taggable-text-area/pom.xml
@@ -10,7 +10,7 @@
 
     <name>Taggable Text Area</name>
 
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <inceptionYear>2024</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/vcf-taggable-text-area/src/main/java/org/vaadin/addons/componentfactory/tta/BaseFilterListSelector.java
+++ b/vcf-taggable-text-area/src/main/java/org/vaadin/addons/componentfactory/tta/BaseFilterListSelector.java
@@ -1,0 +1,95 @@
+/*-
+ * #%L
+ * Taggable Text Area
+ * %%
+ * Copyright (C) 2025 Vaadin Ltd
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.vaadin.addons.componentfactory.tta;
+
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.customfield.CustomField;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.selection.SingleSelect;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.function.SerializableBiFunction;
+import java.util.List;
+
+@SuppressWarnings("serial")
+public abstract class BaseFilterListSelector<T> extends CustomField<T>
+    implements SingleSelect<CustomField<T>, T>, HasStyle {
+
+  private final TextField filter = new TextField();
+
+  /**
+   * Function defining the filter expression, used to match items against the filter query. Defaults
+   * to checking if the string representation of the item contains the filter text.
+   */
+  private SerializableBiFunction<T, String, Boolean> filterExpression =
+      (item, filter) -> filter.contains("" + item);
+
+  private List<T> filteredItems;
+
+  protected void initFilter(List<T> items) {
+    filter.getElement().executeJs("return;")
+        .then(ev -> filter.getElement().executeJs("this.focus();"));
+    filter.setSizeFull();
+    filter.setValueChangeMode(ValueChangeMode.EAGER);
+    filteredItems = items;
+    filter.addKeyPressListener(Key.ENTER, ev -> {
+      if (!filteredItems.isEmpty()) {
+        this.setValue(filteredItems.iterator().next());
+      }
+    });
+  }
+
+  /**
+   * Returns the filter expression used to filter items.
+   *
+   * @return the filter expression
+   */
+  public SerializableBiFunction<T, String, Boolean> getFilterExpression() {
+    return filterExpression;
+  }
+
+  /**
+   * Sets the filter expression used to filter items.
+   *
+   * @param filterExpression the filter expression
+   */
+  public void setFilterExpression(SerializableBiFunction<T, String, Boolean> filterExpression) {
+    this.filterExpression = filterExpression;
+  }
+
+  /**
+   * Returns the filter text field.
+   * 
+   * @return the filter
+   */
+  protected TextField getFilter() {
+    return filter;
+  }
+
+  /**
+   * Returns the filtered items list.
+   * 
+   * @return the filteredItems
+   */
+  protected List<T> getFilteredItems() {
+    return filteredItems;
+  }
+  
+}

--- a/vcf-taggable-text-area/src/main/java/org/vaadin/addons/componentfactory/tta/FilterListSelector.java
+++ b/vcf-taggable-text-area/src/main/java/org/vaadin/addons/componentfactory/tta/FilterListSelector.java
@@ -1,0 +1,178 @@
+/*-
+ * #%L
+ * Taggable Text Area
+ * %%
+ * Copyright (C) 2025 Vaadin Ltd
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.vaadin.addons.componentfactory.tta;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.Shortcuts;
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.grid.Grid.SelectionMode;
+import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * A custom field component that combines a {@link TextField} with a {@link Grid}.
+ * 
+ * <p>
+ * The {@code FilterListSelector} allows to filter items in the list based on text input and select
+ * an item either by pressing Enter or interacting with the {@link Grid}.
+ *
+ * This particular selector is advised to be used when a large amount of items needs to be
+ * displayed.
+ * 
+ * @param <T> the type of items displayed
+ */
+@SuppressWarnings("serial")
+@CssImport(value = "./styles/filter-list-selector.css", themeFor = "vaadin-grid")
+public class FilterListSelector<T> extends BaseFilterListSelector<T> {
+
+  private Grid<T> gridList = new Grid<>();
+  private Column<T> column;
+  private ComponentRenderer<? extends Component, T> itemRenderer;
+  private T selectedItem = null;
+  private T focusedItem = null;
+  private int visibleItems = 10;
+
+  /**
+   * Constructs a {@code FilterListSelector} with the given list of items.
+   *
+   * @param items the list of items to display in the {@link Grid}
+   */
+  public FilterListSelector(List<T> items) {
+    this(items, new ComponentRenderer<>(item -> {
+      HorizontalLayout row = new HorizontalLayout();
+      row.setAlignItems(FlexComponent.Alignment.CENTER);
+
+      Span name = new Span("" + item);
+
+      VerticalLayout column = new VerticalLayout(name);
+      column.setPadding(false);
+      column.setSpacing(false);
+
+      row.add(column);
+      row.getStyle().set("line-height", "var(--lumo-line-height-m)");
+      return row;
+    }));
+  }
+
+  /**
+   * Constructs a {@code FilterListSelector} with the given list of items and the given
+   * itemRenderer.
+   *
+   * @param items the list of items to display in the {@link Grid}
+   * @param itemRenderer the renderer for the items
+   */
+  public FilterListSelector(List<T> items, ComponentRenderer<? extends Component, T> itemRenderer) {
+    setClassName("taggable-textarea-filter-list-selector");
+    this.itemRenderer = itemRenderer;
+
+    gridList.addClassName("taggable-textarea-filter-list-selector-list");
+    gridList.setSelectionMode(SelectionMode.SINGLE);
+    gridList.setItems(items);
+    gridList.addThemeVariants(GridVariant.LUMO_NO_ROW_BORDERS, GridVariant.LUMO_NO_BORDER);
+    gridList.setAllRowsVisible(items.size() < visibleItems);
+    column = gridList.addColumn(this.itemRenderer);
+    column.setClassNameGenerator(c -> "taggable-textarea-filter-list-selector-list-column");
+
+    initFilter(items);
+    TextField filter = getFilter();
+
+    filter.addValueChangeListener(e -> {
+      List<T> filteredItems = getFilteredItems();
+      filteredItems =
+          items.stream().filter(item -> getFilterExpression().apply(item, filter.getValue()))
+              .collect(Collectors.toList());
+      gridList.setItems(filteredItems);
+      gridList.setAllRowsVisible(filteredItems.size() < visibleItems);
+    });
+    filter.getElement().executeJs(
+        "this.addEventListener('keydown', (event) => {" +
+        "    if (event.key === 'ArrowDown') { " +
+        "        const grid = $0;" +
+        "        requestAnimationFrame(() => { " +
+        "            const firstCell = grid.shadowRoot.querySelector('.taggable-textarea-filter-list-selector-list-column');" +
+        "            if (firstCell) {" +
+        "                firstCell.focus({ preventScroll: true });" + 
+        "            }" +
+        "        });" +
+        "    }" +
+        "});",
+        gridList.getElement()
+    );
+
+    // add selection listener to gridList to save the selected item
+    gridList.addSelectionListener(ev -> {
+      Optional<T> optionalSelectedItem = ev.getFirstSelectedItem();
+      selectedItem = optionalSelectedItem.orElse(null);
+      this.setValue(selectedItem);
+    });
+
+    // keep track of the focus item so it can be selected on enter
+    gridList.addCellFocusListener(focusEvent -> {
+      focusedItem = focusEvent.getItem().orElse(null);
+    });
+
+    // add shorcut listener so items can be selected on enter
+    Shortcuts.addShortcutListener(this, event -> {
+      gridList.select(focusedItem);
+    }, Key.ENTER).listenOn(gridList);
+
+    VerticalLayout layout = new VerticalLayout(filter, gridList);
+    layout.setSpacing(false);
+    layout.setPadding(false);
+    layout.setMargin(false);
+    layout.setWidth("auto");
+    layout.setHeight("auto");
+    add(layout);
+  }
+  
+  @Override
+  public T getValue() {
+    return this.selectedItem;
+  }
+  
+  @Override
+  protected T generateModelValue() {
+    return this.selectedItem;
+  }
+
+  @Override
+  protected void setPresentationValue(T newPresentationValue) {
+    gridList.select(newPresentationValue);
+  }
+
+  /**
+   * @param visibleItems the visibleItems to set
+   */
+  public void setVisibleItems(int visibleItems) {
+    this.visibleItems = visibleItems;
+  }
+
+}

--- a/vcf-taggable-text-area/src/main/java/org/vaadin/addons/componentfactory/tta/TaggableTextArea.java
+++ b/vcf-taggable-text-area/src/main/java/org/vaadin/addons/componentfactory/tta/TaggableTextArea.java
@@ -31,11 +31,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValueAndElement;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.orderedlayout.FlexComponent;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextArea;
-import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.function.SerializableFunction;
 
 /**
@@ -270,29 +266,16 @@ public class TaggableTextArea<T> extends TextArea {
 	
     /**
      * Creates the selector field that will be shown inside the popup to select the tag. By default
-     * it will return a listbox containing the items converted to string with the toString() method.
-     * It can be overwritten so it uses a different component for selecting the tags.
+     * it will return a @link {@link FilterListSelector} containing the items converted to string
+     * with the toString() method. It can be overwritten so it uses a different component for
+     * selecting the tags.
      * 
      * @return the selector component
      */
 	protected HasValueAndElement<?,T> createSelector() {
-		FilterListBoxSelector<T> selector = new FilterListBoxSelector<>(this.items);
+		FilterListSelector<T> selector = new FilterListSelector<>(this.items);
 		selector.getElement().executeJs("return;").then(ev->selector.getElement().executeJs("this.focus();"));
 		selector.setFilterExpression((item, filterText) -> item.toString().toLowerCase().contains(filterText.toLowerCase()));
-		selector.setRenderer(new ComponentRenderer<>(item -> {
-		    HorizontalLayout row = new HorizontalLayout();
-		    row.setAlignItems(FlexComponent.Alignment.CENTER);
-
-		    Span name = new Span(""+item);
-
-		    VerticalLayout column = new VerticalLayout(name);
-		    column.setPadding(false);
-		    column.setSpacing(false);
-
-		    row.add(column);
-		    row.getStyle().set("line-height", "var(--lumo-line-height-m)");
-		    return row;
-		}));
 		return selector;
 	}
 

--- a/vcf-taggable-text-area/src/main/java/org/vaadin/addons/componentfactory/tta/TaggableTextArea.java
+++ b/vcf-taggable-text-area/src/main/java/org/vaadin/addons/componentfactory/tta/TaggableTextArea.java
@@ -261,7 +261,7 @@ public class TaggableTextArea<T> extends TextArea {
      * @return the decorated HTML string
      */
 	protected String decorateWithSpan(String label) {
-		return "<span class=\"mention-highlight\" style=\"background-color:var(--lumo-contrast-10pct);color:var(--lumo-primary-text-color)\" id=\"span-" + UUID.randomUUID() + "\">" + label + "</span>";
+		return "<span class=\"mention-highlight\" contenteditable=false style=\"background-color:var(--lumo-contrast-10pct);color:var(--lumo-primary-text-color)\" id=\"span-" + UUID.randomUUID() + "\">" + label + "</span>";
 	}
 	
     /**

--- a/vcf-taggable-text-area/src/main/resources/META-INF/resources/frontend/styles/filter-list-selector.css
+++ b/vcf-taggable-text-area/src/main/resources/META-INF/resources/frontend/styles/filter-list-selector.css
@@ -1,0 +1,3 @@
+.taggable-textarea-filter-list-selector-list-column ::slotted(vaadin-grid-cell-content){
+	padding: 0;
+}


### PR DESCRIPTION
This PR includes changes to fix #2. A new FilterListSelector was created which uses Grid instead of ListBox to display the items to be selected. This change was needed to avoid performance issues when the number of items is quite large. Changes had been made to use this new filter selector as the default one. Also, the demo view was updated to reflect the changes.

This PR also includes a fix to make the decorated span to be not editable. As it was reported that entering text after a highlighted tag, expanded the span and text was added within it, when it should be added outside and without the formatting.

Version was updated to 1.1.0-SNAPSHOT as the PR includes a new feature. 